### PR TITLE
Missing sys.argv when used from embedded python

### DIFF
--- a/oauth2client/tools.py
+++ b/oauth2client/tools.py
@@ -76,6 +76,10 @@ Go to the following link in your browser:
 
 def _CreateArgumentParser():
     try:
+        if hasattr(sys, 'argv'):  # to handle edge case where call is from embedded Python with no argv.
+            import argparse
+        else:
+            return None
         import argparse
     except ImportError:  # pragma: NO COVER
         return None


### PR DESCRIPTION
When the library is being from embedded Python (i.e. not called directly from Python interpreter), sys.argv does not exist which makes the library crash.
To handle this rare edge case, we check that argv is there and we do the import.
If not, we simply return None.

My concrete use case is to use Google Python API with Postgres/Multicorn.
